### PR TITLE
Update newFormValidation.js

### DIFF
--- a/assets/js/personales/newFormValidation.js
+++ b/assets/js/personales/newFormValidation.js
@@ -447,12 +447,12 @@ async function applySuccessToSubmit(formRegister){
 
       const { value: url } = await Swal.fire({
         title:'Formulario Comprobado',
-        text:'¿Desea enviarlo a formfree? Coloque la url',
+        text:'¿Desea enviarlo a formspree o similar? (nota, formfree tiene problemas para aceptar la imagen)',
         icon:'success',
         showCancelButton:true,
         input: "url",
-        inputLabel: "URL address",
-        inputPlaceholder: "Enter the URL"
+        inputLabel: "URL",
+        inputPlaceholder: "Coloque la URL"
       });
       if (url) {
         const form=document.querySelector('#form')


### PR DESCRIPTION
Se modificó el mensaje para enviar el formulario. Recordar que formspree no acepta las imágenes a menos que se actualice la suscripción